### PR TITLE
Fix recipe details

### DIFF
--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -1,7 +1,7 @@
 class FoodsController < ApplicationController
   load_and_authorize_resource
   def index
-    @foods = Food.order(created_at: :desc)
+    @foods = Food.includes(:user).order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/recipe_foods_controller.rb
+++ b/app/controllers/recipe_foods_controller.rb
@@ -29,6 +29,12 @@ class RecipeFoodsController < ApplicationController
     end
   end
 
+  def shopping_list
+    foods = Food.includes(:recipes).where(user: current_user)
+    @filter_food = foods.filter { |food| food.recipes.blank? }
+    @total = @filter_food.sum(&:price)
+  end
+
   private
 
   def recipe_food_params

--- a/app/controllers/recipe_foods_controller.rb
+++ b/app/controllers/recipe_foods_controller.rb
@@ -1,0 +1,14 @@
+class RecipeFoodsController < ApplicationController
+  def create
+    @recipe = Recipe.find(params[:recipe_id])
+  end
+
+  def new
+    @recipe = Recipe.find(params[:recipe_id])
+    @recipe_food = RecipeFood.new
+  end
+
+  def edit
+    @recipe_food = Recipe.find(params[:recipe_id])
+  end
+end

--- a/app/controllers/recipe_foods_controller.rb
+++ b/app/controllers/recipe_foods_controller.rb
@@ -1,6 +1,12 @@
 class RecipeFoodsController < ApplicationController
   def create
     @recipe = Recipe.find(params[:recipe_id])
+    @recipe_food = @recipe.recipe_foods.new(recipe_food_params)
+    if @recipe_food.save
+      redirect_to @recipe
+    else
+      render :new
+    end
   end
 
   def new
@@ -9,6 +15,23 @@ class RecipeFoodsController < ApplicationController
   end
 
   def edit
-    @recipe_food = Recipe.find(params[:recipe_id])
+    @recipe_food = RecipeFood.find(params[:id])
+  end
+
+  def update
+    @recipe_food = RecipeFood.find(params[:id])
+    if @recipe_food.update(recipe_food_params)
+      flash[:succes] = 'Recipe food updated successfully'
+      redirect_to recipe_path(@recipe_food.recipe)
+    else
+      flash[:succes] = 'Recipe food update failed'
+      render :edit
+    end
+  end
+
+  private
+
+  def recipe_food_params
+    params.require(:recipe_food).permit(:quantity, :food_id)
   end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -2,12 +2,11 @@ class RecipesController < ApplicationController
   load_and_authorize_resource
 
   def index
-    @recipes = Recipe.order(created_at: :desc)
+    @recipes = current_user.recipes.includes(:user, :recipe_foods).order(created_at: :desc)
   end
 
   def show
-    @recipe = Recipe.find(params[:id])
-    @foods = Food.order(created_at: :desc)
+    @recipe = Recipe.includes(:recipe_foods).find(params[:id])
   end
 
   def new
@@ -34,15 +33,15 @@ class RecipesController < ApplicationController
   end
 
   def public_recipes
-    @public_recipes = Recipe.includes(:user, :foods,
-                                      :recipe_foods).where(public: true).order(created_at: :desc).map do |recipe|
+    @recipes = Recipe.includes(:user, :foods,
+                               :recipe_foods).where(public: true).order(created_at: :desc).map do |recipe|
       {
         id: recipe.id,
         name: recipe.name,
         description: recipe.description,
         author: recipe.user.name,
         created_at: recipe.created_at,
-        items: recipe.total_count,
+        items: recipe.recipe_foods_count,
         total_price: recipe.foods.map(&:price).sum
       }
     end

--- a/app/helpers/recipe_foods_helper.rb
+++ b/app/helpers/recipe_foods_helper.rb
@@ -1,0 +1,2 @@
+module RecipeFoodsHelper
+end

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -3,7 +3,7 @@
         <div class="col-12">
             <h2 class="d-flex justify-content-center text-primary">List of  foods</h2>
             <h3 class="d-flex justify-content-end">
-             <%= link_to "Add Food", new_user_food_path(current_user.id), class: 'btn btn-primary'%></h3>
+             <%= link_to "Add Food", new_user_food_path(current_user), class: 'btn btn-primary'%></h3>
         </div>
         <div class="col-12">
             <table class="table  table-hover table-bordered table-striped  table-responsive table-foods">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,5 +17,8 @@
     <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
     <%= yield %>
-  </body>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.1/jquery.min.js" integrity="sha512-aVKKRRi/Q/YV+4mjoKBsE4x3H+BkegoM/em46NNlCqNTmUYADjBbeNefNxYV7giUp0VxICtqdrbqU7iVaeZNXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.5/dist/umd/popper.min.js" integrity="sha384-Xe+8cL9oJa6tN/veChSP7q+mnSPaj5Bcu9mPX5F5xIGE0DVittaqT5lorf0EI7Vk" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.min.js" integrity="sha384-ODmDIVzN+pFdexxHEHFBQH3/9/vQ9uori45z4JjnFsRydbmQbmL5t1tQ0culUzyK" crossorigin="anonymous"></script>
+    </body>
 </html>

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -7,8 +7,8 @@
 
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
                 <% if user_signed_in? %>     
-                    <li><%= link_to "Foods", user_foods_path(current_user.id), class:"nav-link px-2 text-white"%></li>
-                    <li><%= link_to "Recipes", user_recipes_path(current_user.id), class:"nav-link px-2 text-white"%></li>
+                    <li><%= link_to "Foods", user_foods_path(current_user), class:"nav-link px-2 text-white"%></li>
+                    <li><%= link_to "Recipes", user_recipes_path(current_user), class:"nav-link px-2 text-white"%></li>
                 <% end %>
             </ul>
             <% if user_signed_in? %>

--- a/app/views/recipe_foods/_new.html.erb
+++ b/app/views/recipe_foods/_new.html.erb
@@ -1,0 +1,9 @@
+<%= form_with model: [@recipe, @recipe.recipe_foods.build], local: true do |f| %>
+  <%= f.label :Ingredient, class:"form-label" %>
+  <%= f.select :food_id, current_user.foods.collect {|food| [food.name, food.id]}, {include_blank: true}, class:"form-select", id:"foodSelect" %>
+  <br>
+  <%= f.label :quantity, class:"form-label" %>
+  <%= f.number_field :quantity, class:"form-control", required: true, placeholder: '1',  min: 1 %>
+  <hr>
+  <%= f.submit "Add food", class:"btn btn-primary" %>
+<% end %>

--- a/app/views/recipe_foods/create.html.erb
+++ b/app/views/recipe_foods/create.html.erb
@@ -1,0 +1,2 @@
+<h1>RecipeFoods#create</h1>
+<p>Find me in app/views/recipe_foods/create.html.erb</p>

--- a/app/views/recipe_foods/edit.html.erb
+++ b/app/views/recipe_foods/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>RecipeFoods#edit</h1>
+<p>Find me in app/views/recipe_foods/edit.html.erb</p>

--- a/app/views/recipe_foods/edit.html.erb
+++ b/app/views/recipe_foods/edit.html.erb
@@ -1,2 +1,13 @@
-<h1>RecipeFoods#edit</h1>
-<p>Find me in app/views/recipe_foods/edit.html.erb</p>
+<div class="container">
+  <h2 class="text-center">Edit Ingredient</h2>
+  <div class="d-flex justify-content-center mt-4" style="width: 60vw; margin:auto">
+      <%= form_with  model: @recipe_food, url: { action: "update"}, local: true, class:"input-form"  do |f|%>
+          <div class="form-group">
+              <%= f.select :food_id, current_user.foods.collect {|food| [food.name, food.id]},{ include_blank: true} , class:"custom-select form-control", id:"inputGroupSelect01" %><br>
+              <%= f.number_field :quantity ,  class:"form-control" , required: true, placeholder: 'Quantity',  min: 1 %><br>
+          </div>
+          <%= link_to "Go back", recipe_path(@recipe_food.recipe.id), class:"btn btn-secondary btn-sm" %> <%= f.submit "Update", class:"btn btn-sm btn-primary" %>
+      <% end %>
+      <br /> 
+  </div>
+</div>

--- a/app/views/recipe_foods/new.html.erb
+++ b/app/views/recipe_foods/new.html.erb
@@ -1,0 +1,2 @@
+<h1>RecipeFoods#new</h1>
+<p>Find me in app/views/recipe_foods/new.html.erb</p>

--- a/app/views/recipe_foods/new.html.erb
+++ b/app/views/recipe_foods/new.html.erb
@@ -1,2 +1,0 @@
-<h1>RecipeFoods#new</h1>
-<p>Find me in app/views/recipe_foods/new.html.erb</p>

--- a/app/views/recipe_foods/shopping_list.html.erb
+++ b/app/views/recipe_foods/shopping_list.html.erb
@@ -1,0 +1,28 @@
+<div class="container">
+  <h3 class="text-center mt-4">Shopping list</h3>
+  <div class="row d-flex justify-content-between">
+    <h5 class="col-md-4">Amount of foods to buy: <%= @filter_food.count %></h5>
+    <h5 class="col-md-4">Total value of of food needed: $<%= @total %></h5>
+  </div>
+  <br>
+  <table class="table table-ligth table-hover">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Name</th>
+        <th scope="col">Quantity</th> 
+        <th scope="col">Unit Price</th>
+      </tr>
+    </thead>
+    <tbody>
+    <% @filter_food.each_with_index do |food, index|%>
+      <tr>
+        <th scope="row"><%= index+1 %></th>
+        <td><%= food.name %></td>
+        <td><%= food.measurement_unit %></td>
+        <td>$<%= food.price %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/recipes/_publuc_index.html.erb
+++ b/app/views/recipes/_publuc_index.html.erb
@@ -5,7 +5,7 @@
             <h3 class="d-flex justify-content-end"><%= link_to "Add Recipe", new_user_recipe_path(current_user.id), class: " btn btn-primary" %></h3>
         </div>
           <div class="recipe-container row p-4">
-            <% @public_recipes.each do |recipe| %>
+            <% @recipes.each do |recipe| %>
             <div class="recipe-item m-2 d-flex justify-content-start">
               <div class="col-md-10 p-2 my-2">
                 <div class="list-group d-column justify-content-start">

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -2,7 +2,7 @@
     <div class="row d-flex justify-content-center">
         <div class="col-12">
             <h2 class="d-flex justify-content-center text-primary">List of Recipes</h2>
-            <h3 class="d-flex justify-content-end"><%= link_to "Add Recipe", new_user_recipe_path(current_user.id), class: " btn btn-primary" %></h3>
+            <h3 class="d-flex justify-content-end"><%= link_to "Add Recipe", new_user_recipe_path(current_user), class: " btn btn-primary" %></h3>
         </div>
  
           <div class="recipe-container row p-4">

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -18,8 +18,10 @@
           <p><h4>Steps:</h4> <%= @recipe.description %></p>
         </div>
         <div class="row d-flex justify-content-between">
-          <button class="col-md-2 btn btn-secondary btn-sm m-4">Generate Shopping List</button>
-          <button type="button" class="col-md-2 btn btn-secondary btn-sm m-4" data-bs-toggle="modal" data-bs-target="#addIngredient">Add Ingredients</button>
+          <%= link_to "Generate Shopping List", shopping_list_path(@recipe), class:"col-md-2 btn btn-secondary btn-sm m-4" %>
+          <% if can? :manage, @recipe %>
+            <button type="button" class="col-md-2 btn btn-secondary btn-sm m-4" data-bs-toggle="modal" data-bs-target="#addIngredient">Add Ingredients</button>
+          <% end %>
         </div>
 
         <hr>
@@ -32,7 +34,7 @@
             <th>Actions</th>
           </thead>
           <tbody>
-          <% @recipe.recipe_foods.each_with_index do |ingredient, index|%>
+          <% @recipe.recipe_foods.each_with_index do |ingredient, index| %>
             <tr>
               <td><%= index+1 %></td>
               <td><%= ingredient.food.name %></td>
@@ -40,9 +42,9 @@
               <td>$ <%= ingredient.food.price %></td>
               <% if can? :manage, @recipe %>
                 <td>
-                  <%= link_to "Edit", edit_recipe_recipe_food_path(@recipe, ingredient), class:"btn btn-sm btn-primary" if can? :manage, @recipe%>
-                  <%= link_to "Delete", recipe_recipe_food_path(@recipe, ingredient), method: :delete, class:"btn btn-sm btn-danger" if can? :manage, @recipe %>
-                  </td>
+                  <%= link_to "Edit", edit_recipe_recipe_food_path(@recipe, ingredient), class:"btn btn-sm btn-primary" if can? :manage, @recipe %>
+                  <%= link_to "Delete", recipe_recipe_food_path(@recipe, ingredient), method: :delete, data: {turbo: false}, class:"btn btn-sm btn-danger" if can? :manage, @recipe %>
+                </td>
               <% end %>
             </tr>
             <% end %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -19,7 +19,7 @@
         </div>
         <div class="row d-flex justify-content-between">
           <button class="col-md-2 btn btn-secondary btn-sm m-4">Generate Shopping List</button>
-          <button class="col-md-2 btn btn-secondary btn-sm m-4">Add Ingredients</button>
+          <button type="button" class="col-md-2 btn btn-secondary btn-sm m-4" data-bs-toggle="modal" data-bs-target="#addIngredient">Add Ingredients</button>
         </div>
 
         <hr>
@@ -40,4 +40,30 @@
           </tbody>
         </table>
     </div>
+</div>
+
+<div class="modal fade" id="addIngredient" tabindex="-1" aria-labelledby="addingredient" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addIngredient">Add Food to <%= @recipe.name %></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <%= form_with model: [@recipe, @recipe.recipe_foods.build] do |f| %>
+          <%= f.select :food_id, current_user.foods.collect {|food| [food.id, food.name]}, class:"form-select", id:"foodSelect" %>
+          <label for="foodSelect" class="label">
+
+          <%= f.number_field :quantity, class:"form-control" %>
+          <label for="foodSelect" class="label">
+
+          <%= f.submut "Add food", class:"btn btn-sucess" %>
+        <% end %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -25,18 +25,27 @@
         <hr>
         <table class="table striped table-hover">
           <thead>
+            <th>No.</th>
             <th>Food</th>
             <th>Quantity</th>
             <th>Value</th>
             <th>Actions</th>
           </thead>
           <tbody>
+          <% @recipe.recipe_foods.each_with_index do |ingredient, index|%>
             <tr>
-              <td>Rice</td>
-              <td>10 kg</td>
-              <td>K100</td>
-              <td></td>
+              <td><%= index+1 %></td>
+              <td><%= ingredient.food.name %></td>
+              <td><%= ingredient.quantity %></td>
+              <td>$ <%= ingredient.food.price %></td>
+              <% if can? :manage, @recipe %>
+                <td>
+                  <%= link_to "Edit", edit_recipe_recipe_food_path(@recipe, ingredient), class:"btn btn-sm btn-primary" if can? :manage, @recipe%>
+                  <%= link_to "Delete", recipe_recipe_food_path(@recipe, ingredient), method: :delete, class:"btn btn-sm btn-danger" if can? :manage, @recipe %>
+                  </td>
+              <% end %>
             </tr>
+            <% end %>
           </tbody>
         </table>
     </div>
@@ -46,23 +55,11 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="addIngredient">Add Food to <%= @recipe.name %></h5>
+        <h5 class="modal-title" id="addIngredient">Add Ingredient to <%= @recipe.name %></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <%= form_with model: [@recipe, @recipe.recipe_foods.build] do |f| %>
-          <%= f.select :food_id, current_user.foods.collect {|food| [food.id, food.name]}, class:"form-select", id:"foodSelect" %>
-          <label for="foodSelect" class="label">
-
-          <%= f.number_field :quantity, class:"form-control" %>
-          <label for="foodSelect" class="label">
-
-          <%= f.submut "Add food", class:"btn btn-sucess" %>
-        <% end %>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary">Save changes</button>
+        <%= render "recipe_foods/new" %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
   patch '/recipes/:id', to: 'recipes#toggle_public', as: :update_recipe
   get '/public_recipes', to: 'recipes#public_recipes', as: :public_recipes
+  get '/shopping_list/:recipe_id', to: 'recipe_foods#shopping_list', as: :shopping_list
 
   resources :recipes, only: [:index, :show]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,4 @@
 Rails.application.routes.draw do
-  get 'recipe_foods/create'
-  get 'recipe_foods/new'
-  get 'recipe_foods/edit'
   devise_for :user
   root 'recipes#public_recipes'
   resources :users, only: [:index, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'recipe_foods/create'
+  get 'recipe_foods/new'
+  get 'recipe_foods/edit'
   devise_for :user
   root 'recipes#public_recipes'
   resources :users, only: [:index, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,9 @@ Rails.application.routes.draw do
   get '/public_recipes', to: 'recipes#public_recipes', as: :public_recipes
   get '/shopping_list/:recipe_id', to: 'recipe_foods#shopping_list', as: :shopping_list
 
-  resources :recipes, only: [:index, :show]
+  # resources :recipes, only: [:index, :show]
 
-  resources :recipes do
+  resources :recipes, only: [:index, :show, :destroy] do
     resources :recipe_foods, only: [:create, :new, :edit, :update, :destroy]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,10 @@ Rails.application.routes.draw do
 
   resources :recipes, only: [:index, :show]
 
+  resources :recipes do
+    resources :recipe_foods, only: [:create, :new, :edit, :update, :destroy]
+  end
+
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end

--- a/db/migrate/20220903065021_add_recipe_food_count_to_recipe.rb
+++ b/db/migrate/20220903065021_add_recipe_food_count_to_recipe.rb
@@ -1,0 +1,5 @@
+class AddRecipeFoodCountToRecipe < ActiveRecord::Migration[7.0]
+  def change
+    add_column :recipes, :recipe_foods_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_02_100910) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_03_065021) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -45,6 +45,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_02_100910) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "total_count", default: 0
+    t.integer "recipe_foods_count"
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 

--- a/spec/helpers/recipe_foods_helper_spec.rb
+++ b/spec/helpers/recipe_foods_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the RecipeFoodsHelper. For example:
+#
+# describe RecipeFoodsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe RecipeFoodsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/recipe_foods_spec.rb
+++ b/spec/requests/recipe_foods_spec.rb
@@ -1,25 +1,24 @@
 require 'rails_helper'
 
-RSpec.describe "RecipeFoods", type: :request do
-  describe "GET /create" do
-    it "returns http success" do
-      get "/recipe_foods/create"
+RSpec.describe 'RecipeFoods', type: :request do
+  describe 'GET /create' do
+    it 'returns http success' do
+      get '/recipe_foods/create'
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /new" do
-    it "returns http success" do
-      get "/recipe_foods/new"
+  describe 'GET /new' do
+    it 'returns http success' do
+      get '/recipe_foods/new'
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /edit" do
-    it "returns http success" do
-      get "/recipe_foods/edit"
+  describe 'GET /edit' do
+    it 'returns http success' do
+      get '/recipe_foods/edit'
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/requests/recipe_foods_spec.rb
+++ b/spec/requests/recipe_foods_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "RecipeFoods", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/recipe_foods/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /new" do
+    it "returns http success" do
+      get "/recipe_foods/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /edit" do
+    it "returns http success" do
+      get "/recipe_foods/edit"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/recipe_foods/create.html.erb_spec.rb
+++ b/spec/views/recipe_foods/create.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "recipe_foods/create.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/recipe_foods/create.html.erb_spec.rb
+++ b/spec/views/recipe_foods/create.html.erb_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "recipe_foods/create.html.erb", type: :view do
+RSpec.describe 'recipe_foods/create.html.erb', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/recipe_foods/edit.html.erb_spec.rb
+++ b/spec/views/recipe_foods/edit.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "recipe_foods/edit.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/recipe_foods/edit.html.erb_spec.rb
+++ b/spec/views/recipe_foods/edit.html.erb_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "recipe_foods/edit.html.erb", type: :view do
+RSpec.describe 'recipe_foods/edit.html.erb', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/recipe_foods/new.html.erb_spec.rb
+++ b/spec/views/recipe_foods/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "recipe_foods/new.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/recipe_foods/new.html.erb_spec.rb
+++ b/spec/views/recipe_foods/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "recipe_foods/new.html.erb", type: :view do
+RSpec.describe 'recipe_foods/new.html.erb', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
### This PR contains the following implementation:

- `Update` Recipe details:
  - If the recipe is public or the user is the owner of the recipe, should display the recipe details as in the wireframe.
  - If the user is the owner of the recipe, should lead to the form that allows the user to add new food.

- `Create` General shopping list view
  - Should show the list of food that is missing for all recipes of the logged-in user (compare the list of food for all recipes with the general food list of that user).

- Should count the total food items and total price of the missing food.
- Made sure that there are no N+1 queries happening.